### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure Usage Plans and API Keys

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -70,7 +70,25 @@ $ cdk deploy --profile test
 ```
 
 ## After Deploy
-Navigate to AWS API Gateway console and test the API with below sample data 
+
+### Retrieve API Key
+After deployment, retrieve the API key value from AWS Console or CLI:
+
+```bash
+aws apigateway get-api-keys --include-values --query "items[?name=='DefaultApiKey'].value" --output text
+```
+
+### Test the API
+The API requires an API key in the `x-api-key` header. Test using curl:
+
+```bash
+curl -X POST https://YOUR_API_ENDPOINT/prod \
+  -H "x-api-key: YOUR_API_KEY_VALUE" \
+  -H "Content-Type: application/json" \
+  -d '{"year":"2023","title":"kkkg","id":"12"}'
+```
+
+Or navigate to AWS API Gateway console and test with the API key and sample data:
 ```json
 {
     "year":"2023", 
@@ -84,6 +102,12 @@ You should get below response
 ```json
 {"message": "Successfully inserted data!"}
 ```
+
+### Usage Plan Limits
+The API is configured with the following per-API-key limits:
+- **Rate Limit:** 100 requests per second
+- **Burst Limit:** 200 requests
+- **Quota:** 10,000 requests per day
 
 ## Performance and Throttling Configuration
 
@@ -139,8 +163,11 @@ artillery run test-config.yml
 **Note:** The values below are placeholders and should be updated based on your load testing results.
 
 **API Gateway Throttling:**
-- Rate Limit: 1000 requests/second (update after testing)
-- Burst Limit: 2000 requests (update after testing)
+- Stage Rate Limit: 1000 requests/second (update after testing)
+- Stage Burst Limit: 2000 requests (update after testing)
+- Per-API-Key Rate Limit: 100 requests/second
+- Per-API-Key Burst Limit: 200 requests
+- Per-API-Key Daily Quota: 10,000 requests
 
 **Lambda Configuration:**
 - Reserved Concurrency: 100 executions (update after testing)


### PR DESCRIPTION
## Summary

This PR implements usage plans and API keys to enable per-client throttling for application-to-application (A2A) API consumers, addressing AWS Well-Architected Framework best practice REL05-BP02.

Fixes #21

## Changes Made

### Usage Plan Configuration
- Created usage plan with per-API-key throttle limits (100 req/s rate, 200 burst)
- Added daily quota of 10,000 requests per API key
- Associated usage plan with API Gateway stage

### API Key Implementation
- Created default API key for API access
- Configured API to require `x-api-key` header on all requests
- Associated API key with usage plan

### Documentation Updates
- Added API key retrieval instructions using AWS CLI
- Documented how to include API key in requests
- Listed usage plan limits (rate, burst, quota)

## Well-Architected Framework Compliance

These changes implement REL05-BP02 per-client throttling to differentiate between API consumers and prevent individual clients from exhausting shared resources.

✅ **Per-Client Throttling**: Each API key has independent rate and burst limits
✅ **Consumer Isolation**: High-volume consumers cannot impact others
✅ **Usage Tracking**: API keys enable monitoring of individual consumer behavior
✅ **Quota Management**: Daily quotas prevent sustained overuse

## Testing

After deployment:
1. Retrieve API key value from AWS Console or using provided CLI command
2. Test API with `x-api-key` header to verify authentication
3. Test without API key to verify 403 Forbidden response
4. Exceed per-key rate limit to verify 429 throttling response
5. Monitor usage metrics per API key in CloudWatch

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added usage plan, API key, and API key requirement
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Added API key usage documentation